### PR TITLE
allow services without packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,11 @@ class ReflectionHandler {
   public getServiceNames() {
     return this.fileDescriptorSet.getFileList().flatMap(files => {
       const packageName = files.getPackage()
+      const packagePrefix = !packageName ? '' : `${packageName}.`
+
       return files
         .getServiceList()
-        .flatMap(service => `${packageName}.${service.getName()}`)
+        .flatMap(service => `${packagePrefix}${service.getName()}`)
     })
   }
 


### PR DESCRIPTION
I noticed that at least the Postman service reflector feature will not work without package name when using this library.

I have no idea how this is supposed to work, but I was running through this tutorial: https://blog.logrocket.com/communicating-between-node-js-microservices-with-grpc/ and noticed the issue.

The reflection server works properly, at least for the examples, when there is no package after this is added.